### PR TITLE
Potential fix for code scanning alert no. 4: Uncontrolled data used in path expression

### DIFF
--- a/Backend/routes/document.py
+++ b/Backend/routes/document.py
@@ -6,6 +6,7 @@ import tensorflow as tf
 from tensorflow.keras.models import load_model
 from PIL import Image, ImageChops, ImageEnhance
 import os
+from werkzeug.utils import secure_filename
 from config import Config
 
 # Load your pre-trained model
@@ -54,7 +55,10 @@ def detect_forgery(current_user_email):  # Now receives email instead of user ob
         return jsonify({'error': 'No file selected.'}), 400
         
     # Save the file temporarily
-    temp_path = os.path.join(Config.UPLOAD_FOLDER, file.filename)
+    filename = secure_filename(file.filename)
+    temp_path = os.path.normpath(os.path.join(Config.UPLOAD_FOLDER, filename))
+    if not temp_path.startswith(Config.UPLOAD_FOLDER):
+        return jsonify({'error': 'Invalid file path.'}), 400
     file.save(temp_path)
     
     try:


### PR DESCRIPTION
Potential fix for [https://github.com/parthpetkar/Hack-AI-Thon-Project/security/code-scanning/4](https://github.com/parthpetkar/Hack-AI-Thon-Project/security/code-scanning/4)

To fix the problem, we need to ensure that the constructed file path is contained within a safe root folder. We can achieve this by normalizing the path using `os.path.normpath` and then checking that the normalized path starts with the root folder. Additionally, we can use `werkzeug.utils.secure_filename` to sanitize the filename and remove any special characters.

1. Import `secure_filename` from `werkzeug.utils`.
2. Use `secure_filename` to sanitize the user-provided filename.
3. Normalize the constructed path using `os.path.normpath`.
4. Check that the normalized path starts with the root folder (`Config.UPLOAD_FOLDER`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
